### PR TITLE
Improve messages

### DIFF
--- a/testmsg.py
+++ b/testmsg.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+from pprint import pprint
+from xmppnotify import build_argparser, build_message
+
+
+commonargs = \
+    ["--hostname", "HOSTNAME",
+     "--hostdisplayname", "HOSTDISPLAYNAME",
+     "-o", "outputline1\noutputline2",
+     "--hostaddress", "127.0.0.1",
+     "--hostaddress6", "::1",
+     "--icingaweb2url", "ICINGAWEB2URL",
+     "--state", "STATE", "--longdatetime", "2019-12-31 23:59:59"]
+
+if __name__ == '__main__':
+    parser = build_argparser()
+
+    args = parser.parse_args(commonargs +
+                             ["--notificationtype", "PROBLEM",
+                              "-e", "servicename",
+                              "--servicedisplayname", "servicedisplayname"])
+    pprint(build_message(args))
+
+    args = parser.parse_args(commonargs +
+                             ["--notificationtype", "RECOVERY",
+                              "--notificationauthorname",
+                              "NOTIFICATIONAUTHORNAME",
+                              "--notificationcomment",
+                              "NOTIFICATIONCOMMENT\nMORE COMMENTS"])
+    pprint(build_message(args))

--- a/xmppnotify.py
+++ b/xmppnotify.py
@@ -27,12 +27,16 @@ class XMPPNotify(ClientXMPP):
 
 
 def build_message(args):
+    # Prefix all output lines by "> "
+    if args.output:
+        output = "> " + args.output.replace("\n", "\n> ")
+    else:
+        output = ""
+
     if args.servicename:
         # service
         message = """[{notificationtype}] {servicedisplayname} on {hostdisplayname} is {servicestate}!
-
-Info: {serviceoutput}
-
+{output}
 When: {longdatetime}
 Ref: {hostname}!{servicename}
 Monitoring host: {monitoringhostname}\
@@ -42,16 +46,14 @@ Monitoring host: {monitoringhostname}\
             servicedisplayname=args.servicedisplayname,
             hostdisplayname=args.hostdisplayname,
             servicestate=args.state,
-            serviceoutput=args.output,
+            output=output,
             longdatetime=args.longdatetime,
             servicename=args.servicename,
             hostname=args.hostname
         )
     else:
         message = """[{notificationtype}] {hostdisplayname} is {hoststate}!
-
-Info: {hostoutput}
-
+{output}
 When: {longdatetime}
 Ref: {hostname}
 Monitoring host: {monitoringhostname}\
@@ -60,7 +62,7 @@ Monitoring host: {monitoringhostname}\
             monitoringhostname=gethostname(),
             hostdisplayname=args.hostdisplayname,
             hoststate=args.state,
-            hostoutput=args.output,
+            output=output,
             longdatetime=args.longdatetime,
             hostname=args.hostname
         )
@@ -72,12 +74,14 @@ Monitoring host: {monitoringhostname}\
         message += "\nIPv6: {}".format(args.hostaddress6)
 
     if args.notificationcomment:
+        # Prefix comment lines by "> "
+        comment = "> " + args.notificationcomment.replace("\n", "\n> ")
         message += """\n
 Comment by {notificationauthorname}
- {notificationcomment}
+{comment}
 """.format(
             notificationauthorname=args.notificationauthorname,
-            notificationcomment=args.notificationcomment
+            comment=comment
         )
 
     if args.icingaweb2url and args.servicename:

--- a/xmppnotify.py
+++ b/xmppnotify.py
@@ -97,13 +97,9 @@ Comment by {notificationauthorname}
     return message
 
 
-if __name__ == '__main__':
-    config = configparser.RawConfigParser()
-    config.read('/etc/xmppnotify.cfg')
-    jid = config.get('Account', 'jid')
-    password = config.get('Account', 'password')
-
+def build_argparser():
     parser = argparse.ArgumentParser(description='XMPP Notifications')
+
     # required
     parser.add_argument('-d', '--longdatetime')
     parser.add_argument('-e', '--servicename')  # service only
@@ -122,6 +118,16 @@ if __name__ == '__main__':
     parser.add_argument('-c', '--notificationcomment')
     parser.add_argument('-i', '--icingaweb2url')
 
+    return parser
+
+
+if __name__ == '__main__':
+    config = configparser.RawConfigParser()
+    config.read('/etc/xmppnotify.cfg')
+    jid = config.get('Account', 'jid')
+    password = config.get('Account', 'password')
+
+    parser = build_argparser()
     args = parser.parse_args()
     message = build_message(args)
 

--- a/xmppnotify.py
+++ b/xmppnotify.py
@@ -31,11 +31,10 @@ def build_message(args):
         # service
         message = """[{notificationtype}] {servicedisplayname} on {hostdisplayname} is {servicestate}!
 
-Info:    {serviceoutput}
+Info: {serviceoutput}
 
-When:    {longdatetime}
-Service: {servicename}
-Host:    {hostname}
+When: {longdatetime}
+Ref: {hostname}!{servicename}
 Monitoring host: {monitoringhostname}\
 """.format(
             notificationtype=args.notificationtype,
@@ -51,10 +50,10 @@ Monitoring host: {monitoringhostname}\
     else:
         message = """[{notificationtype}] {hostdisplayname} is {hoststate}!
 
-Info:    {hostoutput}
+Info: {hostoutput}
 
-When:    {longdatetime}
-Host:    {hostname}
+When: {longdatetime}
+Ref: {hostname}
 Monitoring host: {monitoringhostname}\
 """.format(
             notificationtype=args.notificationtype,

--- a/xmppnotify.py
+++ b/xmppnotify.py
@@ -29,16 +29,16 @@ class XMPPNotify(ClientXMPP):
 def build_message(args):
     if args.servicename:
         # service
-        message = """***** Service Monitoring on {monitoringhostname} *****
-
-{servicedisplayname} on {hostdisplayname} is {servicestate}!
+        message = """[{notificationtype}] {servicedisplayname} on {hostdisplayname} is {servicestate}!
 
 Info:    {serviceoutput}
 
 When:    {longdatetime}
 Service: {servicename}
 Host:    {hostname}
+Monitoring host: {monitoringhostname}\
 """.format(
+            notificationtype=args.notificationtype,
             monitoringhostname=gethostname(),
             servicedisplayname=args.servicedisplayname,
             hostdisplayname=args.hostdisplayname,
@@ -49,15 +49,15 @@ Host:    {hostname}
             hostname=args.hostname
         )
     else:
-        message = """***** Host Monitoring on {monitoringhostname} *****
-
-{hostdisplayname} is {hoststate}!
+        message = """[{notificationtype}] {hostdisplayname} is {hoststate}!
 
 Info:    {hostoutput}
 
 When:    {longdatetime}
 Host:    {hostname}
+Monitoring host: {monitoringhostname}\
 """.format(
+            notificationtype=args.notificationtype,
             monitoringhostname=gethostname(),
             hostdisplayname=args.hostdisplayname,
             hoststate=args.state,

--- a/xmppnotify.py
+++ b/xmppnotify.py
@@ -66,14 +66,14 @@ Monitoring host: {monitoringhostname}\
         )
 
     if args.hostaddress:
-        message += "\nIPv4:    {}".format(args.hostaddress)
+        message += "\nIPv4: {}".format(args.hostaddress)
 
     if args.hostaddress6:
-        message += "\nIPv6:    {}".format(args.hostaddress6)
+        message += "\nIPv6: {}".format(args.hostaddress6)
 
     if args.notificationcomment:
-        message += """
-        \nComment by {notificationauthorname}
+        message += """\n
+Comment by {notificationauthorname}
  {notificationcomment}
 """.format(
             notificationauthorname=args.notificationauthorname,


### PR DESCRIPTION
XMPP messages are different from mail, really. And the clients are different too. They're somewhat closer to SMS. So, XMPP messages should get to the point.

That said, let's improve the messages from xmppnotify!

1. Let's start the message by the notificaton type ("PROBLEM" or "RECOVERY" usually), so the recipient immediately knows, what's up.
2. Remove all cruft, that's useless.
3. Remove boilerplate as much as possible.

This PR basicly does (1) and (3).

Doing (2) needs discussion.