### PR TITLE
set message type to "chat"

### DIFF
--- a/xmppnotify.py
+++ b/xmppnotify.py
@@ -19,7 +19,7 @@ class XMPPNotify(ClientXMPP):
     def session_start(self, event):
         self.send_presence()
         self.get_roster()
-        self.send_message(mto=self.recipient, mbody=self.msg)
+        self.send_message(mto=self.recipient, mbody=self.msg, mtype='chat')
         self.disconnect()
 
     def message(self, msg):


### PR DESCRIPTION
some clients (i.e. Sailfish) do not accept messages without message type