### PR TITLE
Fix sending to MUC with slixmpp >= v1.8.0

### DIFF
--- a/commands-xmppnotify.conf
+++ b/commands-xmppnotify.conf
@@ -26,6 +26,9 @@ template NotificationCommand "xmpp-notification-base" {
       required = true
       value = "$notification_type$"
     }
+    "-S" = {
+      set_if = "$notification_short$"
+      }
   }
 
   vars += {
@@ -38,6 +41,7 @@ template NotificationCommand "xmpp-notification-base" {
     notification_hostname = "$host.name$"
     notification_hostdisplayname = "$host.display_name$"
     notification_useremail = "$user.vars.xmpp$"
+    notification_short = "$user.vars.xmpp_short$"
   }
 }
 

--- a/testmsg.py
+++ b/testmsg.py
@@ -11,7 +11,8 @@ commonargs = \
      "--hostaddress", "127.0.0.1",
      "--hostaddress6", "::1",
      "--icingaweb2url", "ICINGAWEB2URL",
-     "--state", "STATE", "--longdatetime", "2019-12-31 23:59:59"]
+     "--state", "STATE", "--longdatetime", "2019-12-31 23:59:59",
+     "--jid", "recipient@exmaple.net"]
 
 if __name__ == '__main__':
     parser = build_argparser()

--- a/xmppnotify.py
+++ b/xmppnotify.py
@@ -16,7 +16,6 @@ class XMPPNotify(ClientXMPP):
         self.add_event_handler("session_start", self.session_start)
         # self.add_event_handler("message", self.message)
 
-
     async def session_start(self, event):
         self.send_presence()
         await self.get_roster()
@@ -123,13 +122,17 @@ Comment by {notificationauthorname}
 def build_argparser():
     parser = argparse.ArgumentParser(description='XMPP Notifications')
 
+    # General config
+    parser.add_argument('-C', '--config', dest='configfile',
+                        default='/etc/xmppnotify.cfg',
+                        help='Account configuration file (%(default)s)')
+
     # required
     parser.add_argument('-d', '--longdatetime')
     parser.add_argument('-e', '--servicename')  # service only
     parser.add_argument('-l', '--hostname')
     parser.add_argument('-n', '--hostdisplayname')
     parser.add_argument('-o', '--output')  # host or service output
-    parser.add_argument('-r', '--jid')
     parser.add_argument('-s', '--state')  # host or service state
     parser.add_argument('-u', '--servicedisplayname')  # service only
     parser.add_argument('-t', '--notificationtype')
@@ -142,18 +145,22 @@ def build_argparser():
     parser.add_argument('-i', '--icingaweb2url')
     parser.add_argument('-S', '--short', default=False, action='store_true')
 
+    parser.add_argument('-r', '--jid', required=True,
+                        help="Target JID")
+
     return parser
 
 
 if __name__ == '__main__':
+    parser = build_argparser()
+    args = parser.parse_args()
+
     config = configparser.RawConfigParser()
-    config.read('/etc/xmppnotify.cfg')
+    config.read(args.configfile)
     jid = config.get('Account', 'jid')
     password = config.get('Account', 'password')
     nick = config.get('Account', 'nick', fallback = jid.split("@")[0])
 
-    parser = build_argparser()
-    args = parser.parse_args()
     message = build_message(args)
 
     xmpp = XMPPNotify(jid, password, nick, args.jid, message)

--- a/xmppnotify.py
+++ b/xmppnotify.py
@@ -56,42 +56,39 @@ def build_message(args):
 
     if args.servicename:
         # service
-        message = """[{notificationtype}] {servicedisplayname} on {hostdisplayname} is {servicestate}!
-{output}
-When: {longdatetime}
-Ref: {hostname}!{servicename}
-Monitoring host: {monitoringhostname}\
-""".format(
+        message = """[{notificationtype}] {servicedisplayname} on {hostdisplayname} is {servicestate}!\n{output}""".format(
             notificationtype=args.notificationtype,
-            monitoringhostname=gethostname(),
             servicedisplayname=args.servicedisplayname,
             hostdisplayname=args.hostdisplayname,
             servicestate=args.state,
-            output=output,
-            longdatetime=args.longdatetime,
-            servicename=args.servicename,
-            hostname=args.hostname
+            output=output
+
         )
+        if not args.short:
+            message += """\nWhen: {longdatetime}\nRef: {hostname}!{servicename}\nMonitoring host: {monitoringhostname}""".format(
+                longdatetime=args.longdatetime,
+                hostname=args.hostname,
+                servicename=args.servicename,
+                monitoringhostname=gethostname()
+            )
     else:
-        message = """[{notificationtype}] {hostdisplayname} is {hoststate}!
-{output}
-When: {longdatetime}
-Ref: {hostname}
-Monitoring host: {monitoringhostname}\
-""".format(
+        message = """[{notificationtype}] {hostdisplayname} is {hoststate}!\n{output}""".format(
             notificationtype=args.notificationtype,
-            monitoringhostname=gethostname(),
             hostdisplayname=args.hostdisplayname,
             hoststate=args.state,
-            output=output,
+            output=output
+        )
+        if not args.short:
+            message += """\nWhen: {longdatetime}\nRef: {hostname}\nMonitoring host: {monitoringhostname}""".format(
             longdatetime=args.longdatetime,
-            hostname=args.hostname
+            hostname=args.hostname,
+            monitoringhostname=gethostname()
         )
 
-    if args.hostaddress:
+    if not args.short and args.hostaddress:
         message += "\nIPv4: {}".format(args.hostaddress)
 
-    if args.hostaddress6:
+    if not args.short and args.hostaddress6:
         message += "\nIPv6: {}".format(args.hostaddress6)
 
     if args.notificationcomment:
@@ -105,19 +102,20 @@ Comment by {notificationauthorname}
             comment=comment
         )
 
-    if args.icingaweb2url and args.servicename:
-        message += "\n" + args.icingaweb2url + \
-            "/monitoring/service/show?host={hostname}&service={servicename}" \
-            .format(
-                hostname=args.hostname,
-                servicename=args.servicename
-            )
-    elif args.icingaweb2url:
-        message += "\n" + args.icingaweb2url + \
-            "/monitoring/host/show?host={hostname}" \
-            .format(
-                hostname=args.hostname,
-            )
+    if not args.short:
+        if args.icingaweb2url and args.servicename:
+            message += "\n" + args.icingaweb2url + \
+                "/monitoring/service/show?host={hostname}&service={servicename}" \
+                .format(
+                    hostname=args.hostname,
+                    servicename=args.servicename
+                )
+        elif args.icingaweb2url:
+            message += "\n" + args.icingaweb2url + \
+                "/monitoring/host/show?host={hostname}" \
+                .format(
+                    hostname=args.hostname,
+                )
 
     return message
 
@@ -142,6 +140,7 @@ def build_argparser():
     parser.add_argument('-b', '--notificationauthorname')
     parser.add_argument('-c', '--notificationcomment')
     parser.add_argument('-i', '--icingaweb2url')
+    parser.add_argument('-S', '--short', default=False, action='store_true')
 
     return parser
 

--- a/xmppnotify.py
+++ b/xmppnotify.py
@@ -36,7 +36,7 @@ class XMPPNotify(ClientXMPP):
             pass
 
         if recipient_type == "muc":
-            self.plugin['xep_0045'].join_muc(self.recipient, self.nick)
+            await self.plugin['xep_0045'].join_muc_wait(self.recipient, self.nick)
             self.send_message(mto=self.recipient, mbody=self.msg, mtype='groupchat')
         else:
             self.send_message(mto=self.recipient, mbody=self.msg, mtype='chat')


### PR DESCRIPTION
Starting with slixmpp v1.8.0, one has to explicitly wait until the MUC got joined.
Otherwise the message is sent into Nirvana.

 slixmpp v1.8.0 got release nearly two years ago, Debian is on v1.8.3, so I think no version checking is required.