### PR TITLE
Fix sending to MUC with slixmpp v1.8.0

### DIFF
--- a/xmppnotify.py
+++ b/xmppnotify.py
@@ -36,7 +36,7 @@ class XMPPNotify(ClientXMPP):
             pass
 
         if recipient_type == "muc":
-            self.plugin['xep_0045'].join_muc(self.recipient, self.nick)
+            await self.plugin['xep_0045'].join_muc_wait(self.recipient, self.nick)
             self.send_message(mto=self.recipient, mbody=self.msg, mtype='groupchat')
         else:
             self.send_message(mto=self.recipient, mbody=self.msg, mtype='chat')


### PR DESCRIPTION
Starting with slixmpp v1.8.0, one has to explicitly wait until the MUC got joined. Otherwise the message is sent into Nirvana.

slixmpp v1.8.0 got release nearly two years ago, Debian is on v1.8.3, so I think no version checking is required.